### PR TITLE
Updated maths description

### DIFF
--- a/samples/multiship-loading-sample/multiship-loading.ipynb
+++ b/samples/multiship-loading-sample/multiship-loading.ipynb
@@ -79,10 +79,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "| Ship A |     |     |     |     | | Ship B |     |     |     |     | | Ship C   |        |        |        |        |\n",
-    "|--------|-----|-----|-----|-----| |--------|-----|-----|-----|-----| |----------|--------|--------|--------|--------|\n",
-    "| 1      |  5  |  9  |  7  |  3  |-| 1      |  5  |  9  |  7  |  3  |-|   1      |     5  |     9  |     7  |     3  |\n",
-    "| $w_0$  |$w_1$|$w_2$|$w_3$|$w_4$| | $w_5$  |$w_6$|$w_7$|$w_8$|$w_9$| | $w_{10}$ |$w_{11}$|$w_{12}$|$w_{13}$|$w_{14}$|"
+    "|| Ship A |     |     |     |     |  Ship B |     |     |     |     | Ship C   |        |        |        |        |\n",
+    "|---|--------|-----|-----|-----|-----|--------|-----|-----|-----|-----|----------|--------|--------|--------|--------|\n",
+    "|Container weight| 1 |  5  |  9  |  7  |  3  | 1 |  5  |  9  |  7  |  3  | 1 | 5 | 9 | 7 | 3  |\n",
+    "|Weight label|*w<sub>0</sub>*|*w<sub>1</sub>*|*w<sub>2</sub>*|*w<sub>3</sub>*|*w<sub>4</sub>*| *w<sub>5</sub>*|*w<sub>6</sub>*|*w<sub>7</sub>*|*w<sub>8</sub>*|*w<sub>9</sub>*|*w<sub>10</sub>*|*w<sub>11</sub>*|*w<sub>12</sub>*|*w<sub>13</sub>*|*w<sub>14</sub>*|"
    ]
   },
   {
@@ -95,13 +95,13 @@
     "\n",
     "where:\n",
     "\n",
-    "$$ H_{A} = \\sum (w_0 x_0 + w_1 x_1 + w_2 x_2 + w_3 x_3 + w_4 x_4 - EqDistrib)^2 $$\n",
+    "$$ H_{A} = (w_0 x_0 + w_1 x_1 + w_2 x_2 + w_3 x_3 + w_4 x_4 - EqDistrib)^2 $$\n",
     "\n",
-    "$$ H_{B} = \\sum (w_5 x_5 + w_6 x_6 + w_7 x_7 + w_8 x_8 + w_9 x_9 - EqDistrib)^2 $$\n",
+    "$$ H_{B} = (w_5 x_5 + w_6 x_6 + w_7 x_7 + w_8 x_8 + w_9 x_9 - EqDistrib)^2 $$\n",
     "\n",
     "and \n",
     "\n",
-    "$$ H_{C} = \\sum (w_{10} x_{10} + w_{11} x_{11} + w_{12} x_{12} + w_{13} x_{13} + w_{14} x_{14} - EqDistrib)^2 $$"
+    "$$ H_{C} = (w_{10} x_{10} + w_{11} x_{11} + w_{12} x_{12} + w_{13} x_{13} + w_{14} x_{14} - EqDistrib)^2 $$"
    ]
   },
   {
@@ -110,12 +110,45 @@
    "source": [
     "We can expand the above and group the common terms, for example if we expand $H_{A}$, we get:\n",
     "\n",
-    "$$ H_{A} = \\sum ({w_0}^2 {x_0}^2 + {w_1}^2 {x_1}^2 + {w_2}^2 {x_2}^2 + ... + {w_{4}}^2 {x_{4}}^2) +\n",
-    "\\sum(2 (w_0 x_0 * w_1 x_1) + 2 (w_0 x_0 * w_2 x_2) + 2 (w_0 x_0 * w_3 x_3) + 2 (w_0 x_0 * w_4 x_4) + \n",
-    "\\sum(2 (w_1 x_1 * w_2 x_2) + 2 (w_1 x_1 * w_3 x_3) + 2 (w_1 x_1 * w_4 x_4) + \n",
-    "\\sum(2 (w_2 x_2 * w_3 x_3) + 2 (w_2 x_2 * w_4 x_4) + \n",
-    "\\sum(2 (w_3 x_3 * w_4 x_4)\n",
-    "- 2(w_0 x_0 * EqDistrib) - 2(w_1 x_1 * EqDistrib) - 2(w_2 x_2 * EqDistrib) - 2(w_3 x_3 * EqDistrib) - 2(w_4 x_4 * EqDistrib) $$ "
+    "$$\n",
+    "\\begin{align}\n",
+    "H_{A} &= (\\sum_i(w_i x_i) - EqDistrib)^2\\\\ \n",
+    "&= (w_0 x_0 + w_1 x_1 + w_2 x_2 + w_3 x_3 + w_4 x_4 - EqDistrib)^2\\\\\n",
+    "\\end{align}\n",
+    "$$ \n",
+    "\n",
+    "To simplify things for the expansion, let's rename the variables as follows:\n",
+    "\n",
+    "$$\n",
+    "\\begin{align}\n",
+    "w_0 x_0 &= a \\\\\n",
+    "w_1 x_1 &= b \\\\\n",
+    "w_2 x_2 &= c \\\\\n",
+    "w_3 x_3 &= d \\\\\n",
+    "w_4 x_4 &= e \\\\\n",
+    "EqDistrib &= f \\\\\n",
+    "\\end{align}\n",
+    "$$ \n",
+    "\n",
+    "So now we have:\n",
+    "\n",
+    "$$\n",
+    "\\begin{align}\n",
+    "H_{A} &= (\\sum_i(w_i x_i) - EqDistrib)^2\\\\ \n",
+    "&= (w_0 x_0 + w_1 x_1 + w_2 x_2 + w_3 x_3 + w_4 x_4 - EqDistrib)^2\\\\\n",
+    "&= (a + b + c + d + e - f)^2\\\\\n",
+    "&= a^2 + b^2 + c^2 + d^2 + e^2 + f^2 + 2(ab + ac + ad + ae + bc + bd + be + cd + ce + de) - 2(af + bf + cf + df + ef)\n",
+    "\\end{align}\n",
+    "$$ \n",
+    "\n",
+    "Substituting our original values back in, this gives us the following:\n",
+    "\n",
+    "$$\n",
+    "\\begin{align}\n",
+    "H_{A} &= (\\sum_i(w_i x_i) - EqDistrib)^2\\\\ \n",
+    "&= w_0^2 x_0^2 + w_1^2 x_1^2 + w_2^2 x_2^2 + w_3^2 x_3^2 + w_4^2 x_4^2 + EqDistrib ^2 + 2(w_0 x_0 \\cdot w_1 x_1 + w_0 x_0 \\cdot w_2 x_2 + w_0 x_0 \\cdot w_3 x_3 + w_0 x_0 \\cdot w_4 x_4 + w_1 x_1 \\cdot w_2 x_2 + w_1 x_1 \\cdot w_3 x_3 + w_1 x_1 \\cdot w_4 x_4 + w_2 x_2 \\cdot w_3 x_3 + w_2 x_2 \\cdot w_4 x_4 + w_3 x_3 \\cdot w_4 x_4) - 2(w_0 x_0 \\cdot EqDistrib +  w_1 x_1 \\cdot EqDistrib + w_2 x_2 \\cdot EqDistrib + w_3 x_3 \\cdot EqDistrib + w_4 x_4 \\cdot EqDistrib)\n",
+    "\\end{align}\n",
+    "$$ "
    ]
   },
   {
@@ -153,11 +186,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If we expand and group the common terms, you get the following:\n",
+    "If we expand and group the common terms, we get the following:\n",
     "\n",
-    "$$ H_{D} = {w_0}^2 {x_0}^2 + {w_0}^2 {x_5}^2 + {w_0}^2 {x_{10}}^2 +\n",
-    "2 ({w_0}^2 x_0 x_5) + 2 ({w_0}^2 x_0 x_{10}) + 2 ({w_0}^2 x_5 x_{10})\n",
-    "- 2({w_0}^2 x_0) - 2({w_0}^2 x_5) - 2({w_0}^2 x_{10}) + {w_0}^2 $$"
+    "$$ H_{D} = {w_0}^2 {x_0}^2 + {w_0}^2 {x_5}^2 + {w_0}^2 {x_{10}}^2 + {w_0}^2 +\n",
+    "2 ({w_0}^2 x_0 x_5 + {w_0}^2 x_0 x_{10} + {w_0}^2 x_5 x_{10})\n",
+    "- 2({w_0}^2 x_0 + {w_0}^2 x_5 + {w_0}^2 x_{10}) $$"
    ]
   },
   {
@@ -199,7 +232,7 @@
     "\n",
     "$$H = H1 + H2 $$\n",
     "\n",
-    "You will notice that $H1$ and $H2$ have common indices $[i,i]/[m,m]$ and $[i]/[m]$. We will need to be careful to not duplicate them, but sum them, in our final list of Terms describing the cost function."
+    "You will notice that $H1$ and $H2$ have common indices $[i,i]/[m,m]$ and $[i]/[m]$. We will need to be careful to not duplicate them, but sum them, in our final list of terms describing the cost function."
    ]
   },
   {
@@ -559,6 +592,13 @@
     "\n",
     "# jobid = SolveMyProblem(problem, PathRelinkingSolver(workspace))"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -577,7 +617,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.9.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
In summary, the changes are:
- Updated weight index table so the elements align properly
- Removed summation signs in the expansions and H_i definitions as you've already explicitly defined all the summation terms
- Simplified the expression for the expansion to make things easier to read and avoid missing terms (e.g. the EqDistrib^2 got lost in the expansion)
- Removed the ellipsis in the expansion, as only one term had been dropped so we might as well just put the w_3 x_3 back in
- Instead of using the * symbol, have used \cdot which is neater and more consistent with what you'll see in literature. Could also use \times if you want an 'x' symbol, but the dot is more compact 
- Factored out the factors of two so instead of showing 2*a + 2*b + ..., it shows 2(a + b + ...)
