### PR TITLE
Remove deprecated workspace.login() method

### DIFF
--- a/samples/getting-started/1qbit/1qbit.py
+++ b/samples/getting-started/1qbit/1qbit.py
@@ -8,14 +8,9 @@ import time
 
 # Workspace information
 workspace = Workspace(
-    subscription_id = "",  # Add your subscription_id
-    resource_group = "",   # Add your resource_group
-    name = "",             # Add your workspace name
-    location = ""          # Add your workspace location (for example, "westus")
+    resource_id = "", # add the Resource ID of your Azure Quantum workspace
+    location = ""     # add the location of your Azure Quantum workspace (e.g. "westus")
 )
-
-# Login
-workspace.login()
 
 # Define the problem
 problem = Problem(name="My First 1QBit Problem", problem_type=ProblemType.ising)

--- a/samples/getting-started/microsoft-qio/microsoft-qio.py
+++ b/samples/getting-started/microsoft-qio/microsoft-qio.py
@@ -6,14 +6,9 @@ from azure.quantum.optimization import Problem, ProblemType, Term, ParallelTempe
 
 # Workspace information
 workspace = Workspace(
-    subscription_id = "",  # Add your subscription_id
-    resource_group = "",   # Add your resource_group
-    name = "",             # Add your workspace name
-    location = ""          # Add your workspace location (for example, "westus")
+    resource_id = "", # add the Resource ID of your Azure Quantum workspace
+    location = ""     # add the location of your Azure Quantum workspace (e.g. "westus")
 )
-
-# Login
-workspace.login()
 
 # Define the problem
 problem = Problem(name="My First Problem", problem_type=ProblemType.ising)

--- a/samples/job-shop-scheduling/job-shop-sample.ipynb
+++ b/samples/job-shop-scheduling/job-shop-sample.ipynb
@@ -97,13 +97,9 @@
     "from azure.quantum import Workspace\n",
     "\n",
     "workspace = Workspace (\n",
-    "    subscription_id = \"\",  # Add your subscription_id\n",
-    "    resource_group = \"\",   # Add your resource_group\n",
-    "    name = \"\",             # Add your workspace name\n",
-    "    location = \"\"          # Add your workspace location (for example, \"westus\")\n",
-    ")\n",
-    "\n",
-    "workspace.login()"
+    "    resource_id = \"\", # add the Resource ID of your Azure Quantum workspace\n",
+    "    location = \"\"     # add the location of your Azure Quantum workspace (e.g. \"westus\")\n",
+    ")"
    ]
   },
   {

--- a/samples/job-shop-scheduling/job-shop-sample.py
+++ b/samples/job-shop-scheduling/job-shop-sample.py
@@ -12,14 +12,10 @@ from typing import List
 from azure.quantum.optimization import Term
 from azure.quantum import Workspace
 
-workspace = Workspace (
-    subscription_id = "",  # Add your subscription_id
-    resource_group = "",   # Add your resource_group
-    name = "",             # Add your workspace name
-    location = ""          # Add your workspace location (for example, "westus")
+workspace = Workspace(
+    resource_id = "", # add the Resource ID of your Azure Quantum workspace
+    location = ""     # add the location of your Azure Quantum workspace (e.g. "westus")
 )
-
-workspace.login()
 
 # Precedence constraint
 def precedence_constraint(jobs_ops_map:dict, T:int, processing_time:dict, weight:float):

--- a/samples/multiship-loading-sample/multiship-loading-sample.py
+++ b/samples/multiship-loading-sample/multiship-loading-sample.py
@@ -110,10 +110,8 @@ from azure.quantum.optimization.oneqbit import PathRelinkingSolver
 
 # Be sure to fill in the settings below which can be retrieved by running 'az quantum workspace show' in the terminal.
 workspace = Workspace(
-    subscription_id=    "",
-    resource_group=     "",
-    name=               "",
-    location=           ""
+    resource_id = "", # add the Resource ID of your Azure Quantum workspace
+    location = ""     # add the location of your Azure Quantum workspace (e.g. "westus")
 )
 
 def visualize_result(result, containers, ships, target):
@@ -245,8 +243,6 @@ def SolveMyProblem(problem, s):
             print("\rJob ID", Job.id, "failed")
     except BaseException as e:
         print(e)
-
-workspace.login()
 
 # Try to call a solver with different timeout value and see if it affects the results
 SolveMyProblem(problem, SimulatedAnnealing(workspace, timeout=10))

--- a/samples/multiship-loading-sample/multiship-loading.ipynb
+++ b/samples/multiship-loading-sample/multiship-loading.ipynb
@@ -255,13 +255,9 @@
     "\n",
     "# Copy the settings for your workspace below\n",
     "workspace = Workspace (\n",
-    "    subscription_id = \"\",  # Add your subscription_id\n",
-    "    resource_group = \"\",   # Add your resource_group\n",
-    "    name = \"\",             # Add your workspace name\n",
-    "    location = \"\"          # Add your workspace name\n",
-    ")\n",
-    "\n",
-    "workspace.login()"
+    "    resource_id = \"\", # add the Resource ID of your Azure Quantum workspace\n",
+    "    location = \"\"     # add the location of your Azure Quantum workspace (e.g. \"westus\")\n",
+    ")"
    ]
   },
   {

--- a/samples/ship-loading/shipping-sample.ipynb
+++ b/samples/ship-loading/shipping-sample.ipynb
@@ -139,13 +139,9 @@
     "\n",
     "# Copy the settings for your workspace below\n",
     "workspace = Workspace (\n",
-    "    subscription_id = \"\",  # Add your subscription_id\n",
-    "    resource_group = \"\",   # Add your resource_group\n",
-    "    name = \"\",             # Add your workspace name\n",
-    "    location = \"\"          # Add your workspace name\n",
-    ")\n",
-    "\n",
-    "workspace.login()"
+    "    resource_id = \"\", # add the Resource ID of your Azure Quantum workspace\n",
+    "    location = \"\"     # add the location of your Azure Quantum workspace (e.g. \"westus\")\n",
+    ")"
    ]
   },
   {

--- a/samples/ship-loading/shipping-sample.py
+++ b/samples/ship-loading/shipping-sample.py
@@ -8,14 +8,10 @@
 from azure.quantum import Workspace
 
 # Copy the settings for your workspace below
-workspace = Workspace (
-    subscription_id = "",  # Add your subscription_id
-    resource_group = "",   # Add your resource_group
-    name = "",             # Add your workspace name
-    location = ""          # Add your workspace location (for example, "westus")
+workspace = Workspace(
+    resource_id = "", # add the Resource ID of your Azure Quantum workspace
+    location = ""     # add the location of your Azure Quantum workspace (e.g. "westus")
 )
-
-workspace.login()
 
 # Take an array of container weights and return a Problem object that represents the cost function
 from typing import List

--- a/samples/traveling-salesperson/traveling-salesperson.ipynb
+++ b/samples/traveling-salesperson/traveling-salesperson.ipynb
@@ -82,14 +82,9 @@
     "\n",
     "# Connect to your Azure Quantum Workspace\n",
     "workspace = Workspace (\n",
-    "    subscription_id = \"\",  # Add your subscription_id\n",
-    "    resource_group = \"\",   # Add your resource_group\n",
-    "    name = \"\",             # Add your workspace name\n",
-    "    location = \"\"          # Add your workspace location (for example, \"westus\")\n",
-    ")\n",
-    "\n",
-    "# Open the browser and sign in with the generated code (on first login)\n",
-    "workspace.login()"
+    "    resource_id = \"\", # add the Resource ID of your Azure Quantum workspace\n",
+    "    location = \"\"     # add the location of your Azure Quantum workspace (e.g. \"westus\")\n",
+    ")"
    ]
   },
   {

--- a/samples/traveling-salesperson/traveling-salesperson.py
+++ b/samples/traveling-salesperson/traveling-salesperson.py
@@ -16,15 +16,10 @@ from azure.quantum.optimization import SimulatedAnnealing, ParallelTempering, Ha
 from typing import List
 
 # Connect to your Azure Quantum Workspace
-workspace = Workspace (
-    subscription_id = "",  # Add your subscription_id
-    resource_group = "",   # Add your resource_group
-    name = "",             # Add your workspace name
-    location = ""          # Add your workspace location (for example, "westus")
+workspace = Workspace(
+    resource_id = "", # add the Resource ID of your Azure Quantum workspace
+    location = ""     # add the location of your Azure Quantum workspace (e.g. "westus")
 )
-
-# Open the browser and sign in with the generated code (on first login)
-workspace.login()
 
 ### Define variables
 


### PR DESCRIPTION
Also switches to the 2-argument version of the workspace constructor inline with the usage in Docs.